### PR TITLE
防止没有userIdList导致的异常

### DIFF
--- a/lib/src/message_content.dart
+++ b/lib/src/message_content.dart
@@ -59,7 +59,7 @@ class MessageContent implements MessageCoding, MessageContentView {
   }
 
   void decodeMentionedInfo(Map mentionedMap) {
-    if (mentionedMap == null) {
+    if (mentionedMap == null || mentionedMap["userIdList"] == null) {
       return;
     }
     MentionedInfo mentionedInfo = new MentionedInfo();


### PR DESCRIPTION
在实际使用中发现，
web端设置了@人，但是没有传入userIdList，
导致flutter端获取消息时报错，
但其他端无此问题